### PR TITLE
Add "Sync Ortto contact" event for v6 contact sync (giveth-v6-core#426)

### DIFF
--- a/config/example.env
+++ b/config/example.env
@@ -16,6 +16,8 @@ SEGMENT_API_KEY=FAKE_API_KEY
 ORTTO_API_KEY=FAKE_API_KEY
 QACC_ORTTO_API_KEY=FAKE_API_KEY
 ORTTO_ACTIVITY_API=https://api-us.ortto.app/v1/activities/create
+# Finite timeout (ms) for the Ortto activity request; defaults to 10000 if unset/invalid.
+ORTTO_REQUEST_TIMEOUT_MS=10000
 
 #JWT_AUTHORIZATION_ADAPTER=siweMicroservice
 JWT_AUTHORIZATION_ADAPTER=mock

--- a/migrations/1732000000000-seedNotificationTypeSyncOrttoContact.ts
+++ b/migrations/1732000000000-seedNotificationTypeSyncOrttoContact.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+  NOTIFICATION_CATEGORY,
+  NOTIFICATION_TYPE_NAMES,
+} from '../src/types/general';
+import { MICRO_SERVICES } from '../src/utils/utils';
+import {
+  NotificationType,
+  SCHEMA_VALIDATORS_NAMES,
+} from '../src/entities/notificationType';
+
+// giveth-v6-core#426: the v6 → Ortto contact sync event. ORTTO-category so it
+// sends no email and needs no wallet/notification-settings — sendNotification
+// just upserts the Ortto person. Must be seeded for the `givethio` microservice
+// or v6-core's requests 400 with INVALID_NOTIFICATION_TYPE.
+const SyncOrttoContactNotificationType = [
+  {
+    name: NOTIFICATION_TYPE_NAMES.SYNC_ORTTO_CONTACT,
+    description: NOTIFICATION_TYPE_NAMES.SYNC_ORTTO_CONTACT,
+    microService: MICRO_SERVICES.givethio,
+    category: NOTIFICATION_CATEGORY.ORTTO,
+    schemaValidator: SCHEMA_VALIDATORS_NAMES.SYNC_ORTTO_CONTACT,
+  },
+];
+
+export class seedNotificationTypeSyncOrttoContact1732000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.manager.save(
+      NotificationType,
+      SyncOrttoContactNotificationType,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM notification_type WHERE "name" = 'Sync Ortto contact';`,
+    );
+  }
+}

--- a/src/adapters/emailAdapter/orttoAdapter.ts
+++ b/src/adapters/emailAdapter/orttoAdapter.ts
@@ -4,7 +4,7 @@ import { OrttoAdapterInterface } from './orttoAdapterInterface';
 import { MICRO_SERVICES } from '../../utils/utils';
 
 export class OrttoAdapter implements OrttoAdapterInterface {
-  async callOrttoActivity(data: any, microService: string): Promise<void> {
+  async callOrttoActivity(data: any, microService: string): Promise<boolean> {
     try {
       if (!data) {
         throw new Error('callOrttoActivity input data is empty');
@@ -25,11 +25,16 @@ export class OrttoAdapter implements OrttoAdapterInterface {
       };
       data.activities.map((a: any) => logger.debug('orttoActivityCall', a));
       await axios.request(config);
+      return true;
     } catch (e) {
       logger.error('orttoActivityCall error', {
         error: e,
         data,
       });
+      // Report failure (do not throw) so callers that need a confirmed upsert
+      // can react; existing fire-and-forget callers ignore the return value and
+      // keep their previous swallow-and-continue behavior.
+      return false;
     }
   }
 }

--- a/src/adapters/emailAdapter/orttoAdapter.ts
+++ b/src/adapters/emailAdapter/orttoAdapter.ts
@@ -3,6 +3,18 @@ import { logger } from '../../utils/logger';
 import { OrttoAdapterInterface } from './orttoAdapterInterface';
 import { MICRO_SERVICES } from '../../utils/utils';
 
+// Finite timeout so a stalled Ortto connection rejects promptly instead of
+// keeping the notification-center request — and, for the contact sync, its 502
+// retry path — pending indefinitely. Sourced from ORTTO_REQUEST_TIMEOUT_MS with
+// a validated fallback so a missing/garbage value never disables the timeout.
+const DEFAULT_ORTTO_TIMEOUT_MS = 10_000;
+const resolveOrttoTimeoutMs = (): number => {
+  const parsed = Number(process.env.ORTTO_REQUEST_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_ORTTO_TIMEOUT_MS;
+};
+
 export class OrttoAdapter implements OrttoAdapterInterface {
   async callOrttoActivity(data: any, microService: string): Promise<boolean> {
     try {
@@ -17,6 +29,7 @@ export class OrttoAdapter implements OrttoAdapterInterface {
         method: 'post',
         maxBodyLength: Infinity,
         url: process.env.ORTTO_ACTIVITY_API,
+        timeout: resolveOrttoTimeoutMs(),
         headers: {
           'X-Api-Key': apiKey as string,
           'Content-Type': 'application/json',
@@ -27,9 +40,18 @@ export class OrttoAdapter implements OrttoAdapterInterface {
       await axios.request(config);
       return true;
     } catch (e) {
+      // Log only a sanitized summary. NEVER log `data` (it carries the contact's
+      // email / names / v6-user-id) or the raw Axios error (its `config` holds
+      // the `X-Api-Key` header and the request body). Activity ids and the HTTP
+      // status are safe, non-sensitive identifiers that are enough to debug.
+      const activityIds = Array.isArray(data?.activities)
+        ? data.activities.map((a: any) => a?.activity_id)
+        : [];
       logger.error('orttoActivityCall error', {
-        error: e,
-        data,
+        microService,
+        activityIds,
+        status: axios.isAxiosError(e) ? e.response?.status : undefined,
+        message: e instanceof Error ? e.message : String(e),
       });
       // Report failure (do not throw) so callers that need a confirmed upsert
       // can react; existing fire-and-forget callers ignore the return value and

--- a/src/adapters/emailAdapter/orttoAdapterInterface.ts
+++ b/src/adapters/emailAdapter/orttoAdapterInterface.ts
@@ -1,3 +1,7 @@
 export interface OrttoAdapterInterface {
-  callOrttoActivity(data: any, microService: string): Promise<void>;
+  // Resolves `true` when Ortto accepted the activity/merge, `false` when the
+  // Ortto call failed (error is logged, not thrown). Callers that need a
+  // confirmed upsert (e.g. the giveth-v6-core#426 contact sync) branch on this
+  // instead of assuming success from a resolved promise.
+  callOrttoActivity(data: any, microService: string): Promise<boolean>;
 }

--- a/src/adapters/emailAdapter/orttoMockAdapter.ts
+++ b/src/adapters/emailAdapter/orttoMockAdapter.ts
@@ -2,7 +2,8 @@ import { logger } from '../../utils/logger';
 import { OrttoAdapterInterface } from './orttoAdapterInterface';
 
 export class OrttoMockAdapter implements OrttoAdapterInterface {
-  async callOrttoActivity(data: any, microService: string): Promise<void> {
+  async callOrttoActivity(data: any, microService: string): Promise<boolean> {
     logger.debug('OrttoMockAdapter has been called', data, microService);
+    return true;
   }
 }

--- a/src/entities/notificationType.ts
+++ b/src/entities/notificationType.ts
@@ -15,6 +15,7 @@ export const SCHEMA_VALIDATORS_NAMES = {
   SEND_EMAIL_CONFIRMATION: 'sendEmailConfirmation',
   SEND_USER_EMAIL_CONFIRMATION_CODE_FLOW: 'sendUserEmailConfirmationCodeFlow',
   CREATE_ORTTO_PROFILE: 'createOrttoProfile',
+  SYNC_ORTTO_CONTACT: 'syncOrttoContact',
   SUBSCRIBE_ONBOARDING: 'subscribeOnboarding',
   SUPERFLUID: 'userSuperTokensCritical',
   ADMIN_MESSAGE: 'adminMessage',

--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -105,7 +105,13 @@ describe('activityCreator', () => {
         'bol:cm:sourced-from-v6': true,
       });
     } finally {
-      process.env.ENVIRONMENT = original;
+      // Restore exactly: if ENVIRONMENT was unset, delete it rather than
+      // assigning `undefined` (which would leave the string "undefined").
+      if (original === undefined) {
+        delete process.env.ENVIRONMENT;
+      } else {
+        process.env.ENVIRONMENT = original;
+      }
     }
   });
 
@@ -125,6 +131,16 @@ describe('activityCreator', () => {
       'str:cm:v6-user-id': '99',
       'bol:cm:sourced-from-v6': true,
     });
-    expect(result.activities[0].attributes['str:cm:v6-user-id']).to.equal('99');
+    // Absent names are omitted entirely — no `undefined` attributes are sent.
+    expect(result.activities[0].attributes).to.deep.equal({
+      'str:cm:email': 'contact@example.com',
+      'str:cm:v6-user-id': '99',
+    });
+    expect(result.activities[0].attributes).to.not.have.property(
+      'str:cm:firstname',
+    );
+    expect(result.activities[0].attributes).to.not.have.property(
+      'str:cm:lastname',
+    );
   });
 });

--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -52,4 +52,79 @@ describe('activityCreator', () => {
       }),
     );
   });
+
+  // giveth-v6-core#426 — the contact sync's cross-layer contract with v6-core.
+  it('builds the SYNC_ORTTO_CONTACT activity: dedicated inert activity, merges on the v6 user id, stamps the sourced-from-v6 marker', () => {
+    const payload = {
+      email: 'contact@example.com',
+      userId: 42,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    };
+    const result = activityCreator(
+      payload,
+      NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT,
+      MICRO_SERVICES.givethio,
+    );
+    expect(result).to.deep.equal({
+      activities: [
+        {
+          activity_id: 'act:cm:sync-ortto-contact',
+          attributes: {
+            'str:cm:email': 'contact@example.com',
+            'str:cm:firstname': 'Ada',
+            'str:cm:lastname': 'Lovelace',
+            'str:cm:v6-user-id': '42',
+          },
+          fields: {
+            'str::email': 'contact@example.com',
+            'str:cm:v6-user-id': '42',
+            'bol:cm:sourced-from-v6': true,
+          },
+        },
+      ],
+      merge_by: ['str:cm:v6-user-id'],
+    });
+  });
+
+  it('merges the SYNC_ORTTO_CONTACT person on the v6 user id regardless of ENVIRONMENT (AC4 on staging)', () => {
+    const original = process.env.ENVIRONMENT;
+    process.env.ENVIRONMENT = 'production';
+    try {
+      const result = activityCreator(
+        { email: 'contact@example.com', userId: 7 },
+        NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT,
+        MICRO_SERVICES.givethio,
+      );
+      // Never merges by email (that would create a duplicate on re-point), and
+      // never falls through to the generic prod block's 'str:cm:user-id'.
+      expect(result.merge_by).to.deep.equal(['str:cm:v6-user-id']);
+      expect(result.activities[0].fields).to.deep.equal({
+        'str::email': 'contact@example.com',
+        'str:cm:v6-user-id': '7',
+        'bol:cm:sourced-from-v6': true,
+      });
+    } finally {
+      process.env.ENVIRONMENT = original;
+    }
+  });
+
+  it('omits optional names for the SYNC_ORTTO_CONTACT activity (nameless wallet/Turnkey profiles still sync)', () => {
+    const result = activityCreator(
+      { email: 'contact@example.com', userId: 99 },
+      NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT,
+      MICRO_SERVICES.givethio,
+    );
+    // The merge key, email, and marker survive even with no names supplied.
+    expect(result.activities[0].activity_id).to.equal(
+      'act:cm:sync-ortto-contact',
+    );
+    expect(result.merge_by).to.deep.equal(['str:cm:v6-user-id']);
+    expect(result.activities[0].fields).to.deep.equal({
+      'str::email': 'contact@example.com',
+      'str:cm:v6-user-id': '99',
+      'bol:cm:sourced-from-v6': true,
+    });
+    expect(result.activities[0].attributes['str:cm:v6-user-id']).to.equal('99');
+  });
 });

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -356,7 +356,25 @@ export const sendNotification = async (
       microService,
     );
     if (data) {
-      await getEmailAdapter().callOrttoActivity(data, microService);
+      const orttoSucceeded = await getEmailAdapter().callOrttoActivity(
+        data,
+        microService,
+      );
+      // giveth-v6-core#426: the contact-sync event needs a CONFIRMED upsert —
+      // v6-core advances its per-user sync marker only on a 2xx, and relies on
+      // its reconcile cron to retry otherwise. Surface an Ortto-side failure as
+      // a 502 for this event so the caller does not record a false success and
+      // silently stop retrying. Other Ortto events keep their fire-and-forget
+      // behavior (the boolean is ignored).
+      if (
+        !orttoSucceeded &&
+        body.eventName === NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT
+      ) {
+        throw new StandardError({
+          message: errorMessages.ORTTO_CONTACT_SYNC_FAILED,
+          httpStatusCode: 502,
+        });
+      }
     }
     emailStatus = EMAIL_STATUSES.SENT;
   }

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -54,6 +54,14 @@ export const activityCreator = (
         'str:cm:userid': payload.userId?.toString(),
       };
       break;
+    case NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT:
+      attributes = {
+        'str:cm:email': payload.email,
+        'str:cm:firstname': payload.firstName,
+        'str:cm:lastname': payload.lastName,
+        'str:cm:v6-user-id': payload.userId?.toString(),
+      };
+      break;
     case NOTIFICATIONS_EVENT_NAMES.SUPER_TOKENS_BALANCE_DEPLETED:
       attributes = {
         'str:cm:tokensymbol': payload.tokenSymbol,
@@ -214,6 +222,27 @@ export const activityCreator = (
   if (!ORTTO_EVENT_NAMES[orttoEventName]) {
     logger.debug('activityCreator() invalid ORTTO_EVENT_NAMES', orttoEventName);
     return;
+  }
+  // giveth-v6-core#426: the v6 contact sync ALWAYS merges on the stable v6 user
+  // id (unlike the generic block below, which only does so in production), so a
+  // canonical-email change re-points the SAME Ortto person instead of creating
+  // a duplicate. It also stamps the durable `bol:cm:sourced-from-v6` marker so
+  // v6-managed contacts stay distinguishable from legacy v5-sourced ones.
+  if (orttoEventName === NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT) {
+    return {
+      activities: [
+        {
+          activity_id: `act:cm:${ORTTO_EVENT_NAMES[orttoEventName]}`,
+          attributes,
+          fields: {
+            'str::email': payload.email,
+            'str:cm:v6-user-id': payload.userId?.toString(),
+            'bol:cm:sourced-from-v6': true,
+          },
+        },
+      ],
+      merge_by: ['str:cm:v6-user-id'],
+    };
   }
   const fields = {
     'str::email': payload.email,

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -57,10 +57,17 @@ export const activityCreator = (
     case NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT:
       attributes = {
         'str:cm:email': payload.email,
-        'str:cm:firstname': payload.firstName,
-        'str:cm:lastname': payload.lastName,
         'str:cm:v6-user-id': payload.userId?.toString(),
       };
+      // Names are optional (wallet-only / Turnkey profiles frequently have
+      // none); include them only when supplied so we never send `undefined`
+      // attributes to Ortto.
+      if (payload.firstName) {
+        attributes['str:cm:firstname'] = payload.firstName;
+      }
+      if (payload.lastName) {
+        attributes['str:cm:lastname'] = payload.lastName;
+      }
       break;
     case NOTIFICATIONS_EVENT_NAMES.SUPER_TOKENS_BALANCE_DEPLETED:
       attributes = {

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -53,6 +53,7 @@ export enum NOTIFICATION_TYPE_NAMES {
   YOUR_PROJECT_GOT_A_RANK = 'Your project got a rank',
   SUBSCRIBE_ONBOARDING = 'Subscribe onboarding',
   CREATE_ORTTO_PROFILE = 'Create Ortto profile',
+  SYNC_ORTTO_CONTACT = 'Sync Ortto contact',
 
   NOTIFY_REWARD_AMOUNT = 'Notify reward amount',
 }

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -49,6 +49,11 @@ export enum NOTIFICATIONS_EVENT_NAMES {
   SUPER_TOKENS_BALANCE_MONTH = 'One month left in stream balance',
   SUPER_TOKENS_BALANCE_DEPLETED = 'Stream balance depleted',
   CREATE_ORTTO_PROFILE = 'Create Ortto profile',
+  // v6 → Ortto contact sync (giveth-v6-core#426). Distinct from
+  // CREATE_ORTTO_PROFILE: it always merges on the stable v6 user id (so a
+  // canonical-email change re-points the same person instead of duplicating)
+  // and stamps a durable "sourced from v6" marker.
+  SYNC_ORTTO_CONTACT = 'Sync Ortto contact',
   SEND_EMAIL_CONFIRMATION = 'Send email confirmation',
   SEND_USER_EMAIL_CONFIRMATION_CODE_FLOW = 'Send email confirmation code flow',
   SUBSCRIBE_ONBOARDING = 'Subscribe onboarding',
@@ -78,6 +83,11 @@ export const ORTTO_EVENT_NAMES = {
   [NOTIFICATIONS_EVENT_NAMES.PROJECT_BADGE_REVOKE_LAST_WARNING]:
     'second-update-warning',
   [NOTIFICATIONS_EVENT_NAMES.CREATE_ORTTO_PROFILE]: 'created-profile',
+  // Reuse the existing "created-profile" Ortto activity so no new custom
+  // activity has to be defined in the Ortto workspace; the v6 contact sync is
+  // still distinguished on the person by the `bol:cm:sourced-from-v6` marker
+  // and the `str:cm:v6-user-id` field it merges on (see activityCreator).
+  [NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT]: 'created-profile',
   [NOTIFICATIONS_EVENT_NAMES.SEND_EMAIL_CONFIRMATION]:
     'verification-form-email-verification',
   [NOTIFICATIONS_EVENT_NAMES.NOTIFY_REWARD_AMOUNT]: 'notify-reward',

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -83,11 +83,13 @@ export const ORTTO_EVENT_NAMES = {
   [NOTIFICATIONS_EVENT_NAMES.PROJECT_BADGE_REVOKE_LAST_WARNING]:
     'second-update-warning',
   [NOTIFICATIONS_EVENT_NAMES.CREATE_ORTTO_PROFILE]: 'created-profile',
-  // Reuse the existing "created-profile" Ortto activity so no new custom
-  // activity has to be defined in the Ortto workspace; the v6 contact sync is
-  // still distinguished on the person by the `bol:cm:sourced-from-v6` marker
-  // and the `str:cm:v6-user-id` field it merges on (see activityCreator).
-  [NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT]: 'created-profile',
+  // DEDICATED, inert activity (giveth-v6-core#426). We intentionally do NOT
+  // reuse 'created-profile': the contact sync must be side-effect-free (it
+  // creates/updates a contact but sends no email), and it fires again on every
+  // canonical-email re-point, so it must not be bound to any Ortto journey that
+  // could send a (duplicate) welcome email. This activity must exist in the
+  // Ortto workspace with NO automation bound to it.
+  [NOTIFICATIONS_EVENT_NAMES.SYNC_ORTTO_CONTACT]: 'sync-ortto-contact',
   [NOTIFICATIONS_EVENT_NAMES.SEND_EMAIL_CONFIRMATION]:
     'verification-form-email-verification',
   [NOTIFICATIONS_EVENT_NAMES.NOTIFY_REWARD_AMOUNT]: 'notify-reward',

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -184,4 +184,5 @@ export const errorMessages = {
   ERROR_IN_GETTING_ACCESS_TOKEN_BY_AUTHORIZATION_CODE:
     'Error in getting accessToken by authorization code',
   ORTTO_SPECIFIC: 'Ortto specific notification',
+  ORTTO_CONTACT_SYNC_FAILED: 'Failed to upsert the Ortto contact',
 };

--- a/src/utils/validators/segmentAndMetadataValidators.ts
+++ b/src/utils/validators/segmentAndMetadataValidators.ts
@@ -157,6 +157,17 @@ const createOrttoProfileSegmentSchema = Joi.object({
   userId: Joi.number().required(),
 });
 
+// giveth-v6-core#426 contact sync. Names are optional (and may be blank):
+// wallet-only / Turnkey profiles frequently have no first/last name, and they
+// must still sync. `email` + `userId` are the only required keys — `userId` is
+// the stable merge key the Ortto person is deduped on.
+const syncOrttoContactSegmentSchema = Joi.object({
+  email: Joi.string().required(),
+  userId: Joi.number().required(),
+  firstName: Joi.string().allow('', null).optional(),
+  lastName: Joi.string().allow('', null).optional(),
+});
+
 const sendEmailConfirmationSchema = Joi.object({
   email: Joi.string().required(),
   verificationLink: Joi.string().required(),
@@ -197,6 +208,10 @@ export const SEGMENT_METADATA_SCHEMA_VALIDATOR: {
   },
   createOrttoProfile: {
     segment: createOrttoProfileSegmentSchema,
+    metadata: null,
+  },
+  syncOrttoContact: {
+    segment: syncOrttoContactSegmentSchema,
     metadata: null,
   },
   subscribeOnboarding: {


### PR DESCRIPTION
## Summary

Companion notification-center change for **Giveth/giveth-v6-core#426** (Sync v6 users to Ortto as contacts by canonical email). Adds a dedicated event that upserts an Ortto **contact** without sending any email. Pairs with giveth-v6-core PR #441 — **deploy this first** so the new NotificationType is seeded before v6-core starts emitting the event (otherwise v6's requests 400 with `INVALID_NOTIFICATION_TYPE`).

## Changes

- New `Sync Ortto contact` event (`NOTIFICATIONS_EVENT_NAMES` / `NOTIFICATION_TYPE_NAMES`), ORTTO category, `givethio` microservice, with a seed migration for the `NotificationType`.
- `activityCreator` case that, for this event, **always merges the Ortto person on the stable `str:cm:v6-user-id`** (regardless of `ENVIRONMENT`) so a canonical-email change re-points the same contact instead of creating a duplicate, and stamps a durable `bol:cm:sourced-from-v6` person-field marker so v6-managed contacts stay distinguishable from legacy v5 ones. Uses a dedicated inert activity `act:cm:sync-ortto-contact` (not `created-profile`) so the sync can never re-fire a welcome journey.
- `syncOrttoContact` segment validator (`email`, `userId` required; `firstName`/`lastName` optional/blank) so nameless wallet/Turnkey profiles still sync.
- `callOrttoActivity` now returns a boolean success (logs, still doesn't throw); for the `Sync Ortto contact` event, `sendNotification` returns a 502 when the Ortto upsert fails, so v6-core records a false success only when the upsert is confirmed and its reconcile cron retries otherwise. All other Ortto events keep their existing fire-and-forget behavior.

## Deploy prerequisite (Ortto workspace)

The Ortto workspace must define custom fields `str:cm:v6-user-id` and `bol:cm:sourced-from-v6`, and the activity `sync-ortto-contact` with **no** automation/journey bound to it.

## How to Test

1. Run migrations (`yarn db:migrate:run:local`) so the `Sync Ortto contact` type is seeded; set `EMAIL_ADAPTER=mock`.
2. POST `/v1/thirdParty/notifications` (Basic auth, givethio) with `{ eventName: "Sync Ortto contact", segment: { payload: { email, userId } } }`.
3. Confirm the resulting Ortto activity payload merges on `str:cm:v6-user-id`, sets `bol:cm:sourced-from-v6: true`, uses `act:cm:sync-ortto-contact`, and that no email is sent.
4. Confirm a failing Ortto call surfaces as a 502 for this event (and stays fire-and-forget for other events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Ortto contact synchronization using email, user identity, and optional name details.
  - Added validation requiring an email address and user ID.
  - Contact updates use a stable identity to help prevent duplicates.
  - Added configurable Ortto request timeouts, defaulting to 10 seconds.

- **Bug Fixes**
  - Synchronization failures are now clearly reported instead of being recorded as successful.
  - Improved success and failure reporting for contact updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->